### PR TITLE
Pin Supabase function JWT verification in config

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,10 @@
+# Supabase project configuration
+project_id = "ftwtxslonvjgvbaexkwn"
+
+# These functions validate caller auth internally and/or are called by Stripe.
+# Locking verify_jwt in source prevents drift across future deploys.
+[functions.stripe-checkout]
+verify_jwt = false
+
+[functions.stripe-webhook]
+verify_jwt = false


### PR DESCRIPTION
## Summary
- Add committed `supabase/config.toml`
- Pin `verify_jwt = false` for `stripe-checkout` and `stripe-webhook`

## Why
Prevents deploy-time auth config drift and keeps runtime behavior consistent with production expectations.
